### PR TITLE
Fix: 로그인 후 리다이렉션 페이지 변경

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -318,7 +318,7 @@ SITE_ID = 1
 
 
 # 로그인 후 리디렉션할 페이지
-LOGIN_REDIRECT_URL = 'https://likelion-start.site/'
+LOGIN_REDIRECT_URL = 'https://likelion-start.site/signup'
 # 로그아웃 후 리디렉션할 페이지
 ACCOUNT_LOGOUT_REDIRECT_URL = '/'
 # 로그아웃 버튼 클릭 시 자동 로그아웃


### PR DESCRIPTION
'https://likelion-start.site/signup'

## 🔍 What is the PR?

로그인 후 signup page 추가에 따른 리다이렉션 페이지 url 변경
> 'https://likelion-start.site/signup'


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

이후 signup 페이지에 생성에 따른 "isSingend" : "boolean" 데이터 던져주는 로직 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

<!-- ex) #3 -->